### PR TITLE
Allow for custom pin mappings and some other tweaks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-firmware/pico-sdk
 firmware/source/build/
 firmware/source/config.h
 examples/external/ressources/sound/music.wav

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 *.txt.user
 __pycache__
 venv/
+.vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "firmware/pico-sdk"]
+	path = firmware/pico-sdk
+	url = https://github.com/raspberrypi/pico-sdk.git

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -23,11 +23,7 @@ Then reboot or reload udev rules:
 
 ## Build firmware
 
-In u2if/firmware/, clone pico-sdk (v1.1.0):
- - git clone https://github.com/raspberrypi/pico-sdk.git
- - cd pico-sdk
- - git reset --hard 1.1.0
- - git submodule update --init
+ - git submodule update --init   # Bring in pico-sdk submodule
 
 In u2if/firmware/source directory:
  - mkdir build
@@ -36,4 +32,3 @@ In u2if/firmware/source directory:
  - make
 
 The firmware to upload to Pico is u2if/firmware/source/build/u2if.uf2
-

--- a/firmware/source/CMakeLists.txt
+++ b/firmware/source/CMakeLists.txt
@@ -12,6 +12,12 @@ project(u2if VERSION "0.3.0")
 # initialize the Pico SDK
 pico_sdk_init()
 
+# define board, pico is default
+# BOARD_FEATHER, BOARD_ITSYBITSY, BOARD_QTPY, BOARD_QT2040_TRINKEY
+add_compile_definitions(BOARD_FEATHER)
+# might help for feather?
+#add_compile_definitions(PICO_DEFAULT_BOOT_STAGE2_FILE=${CMAKE_CURRENT_SOURCE_DIR}/../pico-sdk/src/rp2_common/boot_stage2/boot2_generic_03h.S)
+
 # Enable wanted peripherals
 set(I2C0_ENABLE 1)
 set(I2C1_ENABLE 1)

--- a/firmware/source/interfaces/I2cMaster.cpp
+++ b/firmware/source/interfaces/I2cMaster.cpp
@@ -1,7 +1,6 @@
 #include "I2cMaster.h"
 #include "string.h"
 
-
 I2CMaster::I2CMaster(uint8_t i2cIndex, uint streamBufferSize = 512)
     : StreamedInterface(streamBufferSize),
       _i2cInst(i2cIndex == 0 ? i2c0 : i2c1),

--- a/firmware/source/interfaces/PicoInterfacesBoard.h
+++ b/firmware/source/interfaces/PicoInterfacesBoard.h
@@ -1,6 +1,8 @@
 #ifndef _PICO_INTERFACES_BOARD_H
 #define _PICO_INTERFACES_BOARD_H
 
+#include "pins.h"
+
 #define HID_CMD_SIZE 64
 #define HID_RESPONSE_SIZE 64
 
@@ -22,29 +24,29 @@ namespace Pin {
         GP27_ADC1 = 27,
 
         // UART0
-        GP0_UART0_TX = 0,
-        GP1_UART0_RX = 1,
+        GP0_UART0_TX = U2IF_UART0_TX,
+        GP1_UART0_RX = U2IF_UART0_RX,
 
         // SPI0
-        GP18_SPI0_CK = 18,
-        GP19_SPI0_MOSI = 19,
-        GP16_SPI0_MISO = 16,
+        GP18_SPI0_CK = U2IF_SPI0_CK,
+        GP19_SPI0_MOSI = U2IF_SPI0_MOSI,
+        GP16_SPI0_MISO = U2IF_SPI0_MISO,
         GP17_SPI0_CS1 = 17,
         GP20_SPI0_CS2 = 20,
 
         // SPI1
-        GP10_SPI1_CK = 10,
-        GP11_SPI1_MOSI = 11,
-        GP12_SPI1_MISO = 12,
+        GP10_SPI1_CK = U2IF_SPI1_CK,
+        GP11_SPI1_MOSI = U2IF_SPI1_MOSI,
+        GP12_SPI1_MISO = U2IF_SPI1_MISO,
         GP13_SPI1_CS1 = 13,
 
         // I2C0
-        GP4_I2C0_SDA = 4,
-        GP5_I2C0_SCL = 5,
+        GP4_I2C0_SDA = U2IF_I2C0_SDA,
+        GP5_I2C0_SCL = U2IF_I2C0_SCL,
 
         // I2C1
-        GP14_I2C1_SDA = 14,
-        GP15_I2C1_SCL = 15
+        GP14_I2C1_SDA = U2IF_I2C1_SDA,
+        GP15_I2C1_SCL = U2IF_I2C1_SCL
     };
 }
 

--- a/firmware/source/interfaces/Pwm.h
+++ b/firmware/source/interfaces/Pwm.h
@@ -25,7 +25,7 @@ struct Slice {
             return gpioChannelB = gpio;
     }
 
-    inline bool unsetGpioChannel(uint channel) {
+    inline void unsetGpioChannel(uint channel) {
         if(channel == 0)
             gpioChannelA = -1;
         else
@@ -60,4 +60,3 @@ protected:
 
 
 #endif
-

--- a/firmware/source/interfaces/StreamBuffer.h
+++ b/firmware/source/interfaces/StreamBuffer.h
@@ -12,7 +12,7 @@ public:
     inline uint32_t getAllocateSize() const {return static_cast<uint32_t>(_buffer.size()*4);}
     inline uint8_t* getDataPtr8() {return (uint8_t*)_buffer.data();}
     inline uint32_t* getDataPtr32() {return static_cast<uint32_t*>(_buffer.data());}
-    inline uint32_t setSize(uint32_t size) {_bufSize = size;}
+    inline void setSize(uint32_t size) {_bufSize = size;}
     inline uint32_t size() const {return _bufSize;}
 protected:
     //std::vector<uint8_t> _buffer;
@@ -22,4 +22,3 @@ protected:
 
 
 #endif
-

--- a/firmware/source/interfaces/pins.h
+++ b/firmware/source/interfaces/pins.h
@@ -1,9 +1,39 @@
-#define BOARD_FEATHER
+/**
+ * Pin Mappings
+ * 
+ * For now, pins are assigned for all interfaces, even if not routed. This
+ * doesn't seem to cause any issues, and unused interfaces are not exposed
+ * in Blinka.
+ *
+*/
 
-#if defined (BOARD_QTPY)
+//---------------------------------------------------------
+// Feather 
+//---------------------------------------------------------
+#if defined (BOARD_FEATHER)
+  // I2C0
+  #define U2IF_I2C0_SDA 4
+  #define U2IF_I2C0_SCL 5
+  // I2C1
+  #define U2IF_I2C1_SDA 2
+  #define U2IF_I2C1_SCL 3
+  // SPI0
+  #define U2IF_SPI0_CK 18
+  #define U2IF_SPI0_MOSI 19
+  #define U2IF_SPI0_MISO 20
+  // SPI1
+  #define U2IF_SPI1_CK 10
+  #define U2IF_SPI1_MOSI 11
+  #define U2IF_SPI1_MISO 12
+  // UART0
+  #define U2IF_UART0_TX 0
+  #define U2IF_UART0_RX 1
+
 //---------------------------------------------------------
 // QT Py
 //---------------------------------------------------------
+#elif defined (BOARD_QTPY)
+
   // I2C0
   #define U2IF_I2C0_SDA 24
   #define U2IF_I2C0_SCL 25
@@ -22,10 +52,11 @@
   #define U2IF_UART0_TX 20
   #define U2IF_UART0_RX 5
 
-#elif defined (BOARD_ITSYBITSY)
 //---------------------------------------------------------
 // Itsy Bitsy
 //---------------------------------------------------------
+#elif defined (BOARD_ITSYBITSY)
+
   // I2C0
   #define U2IF_I2C0_SDA 4
   #define U2IF_I2C0_SCL 5
@@ -44,32 +75,34 @@
   #define U2IF_UART0_TX 0
   #define U2IF_UART0_RX 1
 
-#elif defined (BOARD_FEATHER)
 //---------------------------------------------------------
-// Feather 
+// QT2040 Trinkey
 //---------------------------------------------------------
+#elif defined (BOARD_QT2040_TRINKEY)
+
   // I2C0
-  #define U2IF_I2C0_SDA 4
-  #define U2IF_I2C0_SCL 5
+  #define U2IF_I2C0_SDA 16
+  #define U2IF_I2C0_SCL 17
   // I2C1
   #define U2IF_I2C1_SDA 2
   #define U2IF_I2C1_SCL 3
   // SPI0
-  #define U2IF_SPI0_CK 18
-  #define U2IF_SPI0_MOSI 19
-  #define U2IF_SPI0_MISO 20
+  #define U2IF_SPI0_CK 6
+  #define U2IF_SPI0_MOSI 7
+  #define U2IF_SPI0_MISO 8
   // SPI1
   #define U2IF_SPI1_CK 10
   #define U2IF_SPI1_MOSI 11
   #define U2IF_SPI1_MISO 12
   // UART0
-  #define U2IF_UART0_TX 0
-  #define U2IF_UART0_RX 1
+  #define U2IF_UART0_TX 1
+  #define U2IF_UART0_RX 2
 
-#elif defined (BOARD_PICO)
 //---------------------------------------------------------
 // Pico (default)
 //---------------------------------------------------------
+#else
+
   // I2C0
   #define U2IF_I2C0_SDA 4
   #define U2IF_I2C0_SCL 5

--- a/firmware/source/interfaces/pins.h
+++ b/firmware/source/interfaces/pins.h
@@ -1,0 +1,91 @@
+#define BOARD_FEATHER
+
+#if defined (BOARD_QTPY)
+//---------------------------------------------------------
+// QT Py
+//---------------------------------------------------------
+  // I2C0
+  #define U2IF_I2C0_SDA 24
+  #define U2IF_I2C0_SCL 25
+  // I2C1
+  #define U2IF_I2C1_SDA 22
+  #define U2IF_I2C1_SCL 23
+  // SPI0
+  #define U2IF_SPI0_CK 6
+  #define U2IF_SPI0_MOSI 3
+  #define U2IF_SPI0_MISO 4
+  // SPI1
+  #define U2IF_SPI1_CK 10
+  #define U2IF_SPI1_MOSI 11
+  #define U2IF_SPI1_MISO 12
+  // UART0
+  #define U2IF_UART0_TX 20
+  #define U2IF_UART0_RX 5
+
+#elif defined (BOARD_ITSYBITSY)
+//---------------------------------------------------------
+// Itsy Bitsy
+//---------------------------------------------------------
+  // I2C0
+  #define U2IF_I2C0_SDA 4
+  #define U2IF_I2C0_SCL 5
+  // I2C1
+  #define U2IF_I2C1_SDA 2
+  #define U2IF_I2C1_SCL 3
+  // SPI0
+  #define U2IF_SPI0_CK 18
+  #define U2IF_SPI0_MOSI 19
+  #define U2IF_SPI0_MISO 20
+  // SPI1
+  #define U2IF_SPI1_CK 10
+  #define U2IF_SPI1_MOSI 11
+  #define U2IF_SPI1_MISO 12
+  // UART0
+  #define U2IF_UART0_TX 0
+  #define U2IF_UART0_RX 1
+
+#elif defined (BOARD_FEATHER)
+//---------------------------------------------------------
+// Feather 
+//---------------------------------------------------------
+  // I2C0
+  #define U2IF_I2C0_SDA 4
+  #define U2IF_I2C0_SCL 5
+  // I2C1
+  #define U2IF_I2C1_SDA 2
+  #define U2IF_I2C1_SCL 3
+  // SPI0
+  #define U2IF_SPI0_CK 18
+  #define U2IF_SPI0_MOSI 19
+  #define U2IF_SPI0_MISO 20
+  // SPI1
+  #define U2IF_SPI1_CK 10
+  #define U2IF_SPI1_MOSI 11
+  #define U2IF_SPI1_MISO 12
+  // UART0
+  #define U2IF_UART0_TX 0
+  #define U2IF_UART0_RX 1
+
+#elif defined (BOARD_PICO)
+//---------------------------------------------------------
+// Pico (default)
+//---------------------------------------------------------
+  // I2C0
+  #define U2IF_I2C0_SDA 4
+  #define U2IF_I2C0_SCL 5
+  // I2C1
+  #define U2IF_I2C1_SDA 14
+  #define U2IF_I2C1_SCL 15
+  // SPI0
+  #define U2IF_SPI0_CK 18
+  #define U2IF_SPI0_MOSI 19
+  #define U2IF_SPI0_MISO 16
+  // SPI1
+  #define U2IF_SPI1_CK 10
+  #define U2IF_SPI1_MOSI 11
+  #define U2IF_SPI1_MISO 12
+  // UART0
+  #define U2IF_UART0_TX 0
+  #define U2IF_UART0_RX 1
+
+#endif

--- a/firmware/source/usb_descriptors.c
+++ b/firmware/source/usb_descriptors.c
@@ -38,11 +38,29 @@
  */
 #define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
 
-#define BOARD_FEATHER
 #if defined(BOARD_FEATHER)
+  #define USB_MFG "Adafruit"
+  #define USB_PRD "Feather RP2040 U2IF"
   #define USB_VID 0x239A
-  #define USB_PID 0x80F2
+  #define USB_PID 0x00F1
+#elif defined(BOARD_ITSYBITSY)
+  #define USB_MFG "Adafruit"
+  #define USB_PRD "ItsyBitsy RP2040 U2IF"
+  #define USB_VID 0x239A
+  #define USB_PID 0x00FD
+#elif defined(BOARD_QTPY)
+  #define USB_MFG "Adafruit"
+  #define USB_PRD "QT Py RP2040 U2IF"
+  #define USB_VID 0x239A
+  #define USB_PID 0x00F7
+#elif defined(BOARD_QT2040_TRINKEY)
+  #define USB_MFG "Adafruit"
+  #define USB_PRD "QT2040 Trinkey U2IF"
+  #define USB_VID 0x239A
+  #define USB_PID 0x0109
 #else
+  #define USB_MFG "Pico"
+  #define USB_PRD "U2IF"
   #define USB_VID 0xCAFE
   #define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
                             _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
@@ -154,8 +172,8 @@ uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
 char const *string_desc_arr[] =
         {
                 (const char[]) {0x09, 0x04}, // 0: is supported language is English (0x0409)
-                "Pico",                     // 1: Manufacturer
-                "U2IF",              // 2: Product
+                USB_MFG,                     // 1: Manufacturer
+                USB_PRD,              // 2: Product
                 "",                      // 3: Serials, should use chip ID
                 "CDC Streamed data channel"  ,           // 4: CDC Interface
                 "HID Command channel",                     // 5: HID

--- a/firmware/source/usb_descriptors.c
+++ b/firmware/source/usb_descriptors.c
@@ -37,8 +37,16 @@
  *   [MSB]         HID | MSC | CDC          [LSB]
  */
 #define _PID_MAP(itf, n)  ( (CFG_TUD_##itf) << (n) )
-#define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
-                           _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
+
+#define BOARD_FEATHER
+#if defined(BOARD_FEATHER)
+  #define USB_VID 0x239A
+  #define USB_PID 0x80F2
+#else
+  #define USB_VID 0xCAFE
+  #define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
+                            _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
+#endif
 
 //--------------------------------------------------------------------+
 // Device Descriptors
@@ -58,7 +66,7 @@ tusb_desc_device_t const desc_device =
                 
                 .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
 
-                .idVendor           = 0xCafe,
+                .idVendor           = USB_VID,
                 .idProduct          = USB_PID,
                 .bcdDevice          = 0x0100,
 


### PR DESCRIPTION
These are changes to just the firmware aspect of the code repository. As discussed in #2 .

The main change here is a simple pin mapping capability driven by pre-processor logic. This allows creating u2if firmware builds for other RP2040 based boards that route different pins out. The pins are defined in `pins.h` and then mapped to u2if in `PicoInterfacesBoard.h`. Then in `CMakeLists.txt`, set the target board before building. I'm super unfamiliar with cmake, so there may be a better "cmake way" of doing this?

The original variable names in `PicoInterfacesBoard.h` were left in place. For example:
```cpp
        GP18_SPI0_CK = U2IF_SPI0_CK,
```
may not have anything to do with GP18. It's just "pin to use for index 0 SPI clock". This was done to simply allow changing as little code as possible.

Also, currently all interfaces are defined and left enabled. For boards that don't route out all of these, unused pins are specified. Might make sense to have the interfaces be enabled conditionally also. But deferring that work for now.

Additional changes are:
* Includes pin mappings for several Adafruit RP2040 based boards
* Change to including pico-sdk as a submodule
* Minor code fixes that help when building firmware with newer gcc versions