### PR TITLE
change _i2c_scan from doing writes to a single read

### DIFF
--- a/firmware/build-all.sh
+++ b/firmware/build-all.sh
@@ -30,4 +30,5 @@ build feather FEATHER 0 0 1000 0
 build itsybitsy ITSYBITSY 0 0 1000 0
 build qtpy QTPY 0 0 1000 0
 build qt2040_trinkey QT2040_TRINKEY 0 0 1000 0
-
+build seeed_xiao SEEED_XIAO 0 0 1000 0
+build waveshare_zero WAVESHARE_ZERO 0 0 1000 0

--- a/firmware/source/CMakeLists.txt
+++ b/firmware/source/CMakeLists.txt
@@ -14,7 +14,7 @@ pico_sdk_init()
 
 
 set(BOARD "PICO" CACHE STRING "BaseName chosen by the user at CMake configure time")
-set_property(CACHE BOARD PROPERTY STRINGS PICO FEATHER ITSYBITSY QTPY QT2040_TRINKEY)
+set_property(CACHE BOARD PROPERTY STRINGS PICO FEATHER ITSYBITSY QTPY QT2040_TRINKEY SEEED_XIAO WAVESHARE_ZERO)
 message(STATUS "Selected board:'${BOARD}'")
 
 # might help for feather?

--- a/firmware/source/board_config.h.in
+++ b/firmware/source/board_config.h.in
@@ -13,6 +13,8 @@
 #define ITSYBITSY       3
 #define QTPY            4
 #define QT2040_TRINKEY  5
+#define SEEED_XIAO      6
+#define WAVESHARE_ZERO  7
 
 #define BOARD ${BOARD}
 
@@ -168,6 +170,42 @@
   #define U2IF_I2S_SD  12
   // HUB75
   #define HUB75_ENABLED  HUB75_ALLOW
+  
+//---------------------------------------------------------
+// SEEED_XIAO
+//---------------------------------------------------------
+#elif BOARD == SEEED_XIAO
+  // I2C1
+  #define I2C1_ENABLED 1
+  #define U2IF_I2C1_SDA 6
+  #define U2IF_I2C1_SCL 7
+  // SPI0
+  #define SPI0_ENABLED 1
+  #define U2IF_SPI0_CK 2
+  #define U2IF_SPI0_MOSI 3
+  #define U2IF_SPI0_MISO 4
+  // UART0
+  #define UART0_ENABLED 1
+  #define U2IF_UART0_TX 0
+  #define U2IF_UART0_RX 1
+
+//---------------------------------------------------------
+// WAVESHARE_ZERO
+//---------------------------------------------------------
+#elif BOARD == WAVESHARE_ZERO
+  // I2C1
+  #define I2C1_ENABLED 1
+  #define U2IF_I2C1_SDA 14
+  #define U2IF_I2C1_SCL 15
+  // SPI1
+  #define SPI1_ENABLED 1
+  #define U2IF_SPI1_CK 10
+  #define U2IF_SPI1_MOSI 11
+  #define U2IF_SPI1_MISO 12
+  // UART0
+  #define UART0_ENABLED 1
+  #define U2IF_UART0_TX 0
+  #define U2IF_UART0_RX 1  
   
 #else
   #warning "Please define board type"

--- a/firmware/source/usb_descriptors.c
+++ b/firmware/source/usb_descriptors.c
@@ -65,6 +65,16 @@
   #define USB_VID 0xCAFE
   #define USB_PID           (0x4000 | _PID_MAP(CDC, 0) | _PID_MAP(MSC, 1) | _PID_MAP(HID, 2) | \
                             _PID_MAP(MIDI, 3) | _PID_MAP(VENDOR, 4) )
+#elif BOARD == WAVESHARE_ZERO
+ #define USB_MFG "Waveshare"
+  #define USB_PRD "RP2040-Zero U2IF"
+  #define USB_VID 0x2E8A
+  #define USB_PID 0x101F
+#elif BOARD == SEEED_XIAO
+ #define USB_MFG "Seeed Studio"
+  #define USB_PRD "XIAO RP2040 U2IF"
+  #define USB_VID 0x2E8A
+  #define USB_PID 0x0005
 #else
   #warning "Please define board type"
 #endif

--- a/source/machine/i2c.py
+++ b/source/machine/i2c.py
@@ -65,7 +65,7 @@ class I2C(object):
         found = []
         for addr in range(start, end + 1):
             try:
-                self._i2c_writeto(addr, b"\x00\x00\x00")
+                self.readfrom(addr, b"\x01")
             except RuntimeError:
                 continue
             found.append(addr)

--- a/source/machine/u2if.py
+++ b/source/machine/u2if.py
@@ -11,6 +11,8 @@ COMPATIBLE_BOARD_PID_VID = [
     (0x239a, 0x00fd),  # Adafruit ItsyBitsy
     (0x239a, 0x0109),  # Adafruit QT2040 Trinket
     (0x239a, 0x00f7),  # Adafruit QTPY
+    (0x2e8a, 0x0005),  # Seeed Xiao RP2040
+    (0x2e8a, 0x101f),  # Waveshare Zero
 ]
 
 


### PR DESCRIPTION
I was not able to detect VCNL4010 ambient light and proximity sensor as it will not ACK a write to an invalid internal address (address 0x00 is not valid). It will ACK to a read of an invalid address. As micropython does not have a I2C quick command, a proper I2C scan is not possible to implement... so as a compromise a single byte read should be attempted instead of a multi-byte write. As most i2c device reads will use a repeated start after the address is written, a single byte read will most likely be ACK-ed by the majority of devices.