### PR TITLE
Disable GPIO pull when Pin.PULL_NONE

### DIFF
--- a/firmware/source/interfaces/Gpio.cpp
+++ b/firmware/source/interfaces/Gpio.cpp
@@ -130,7 +130,7 @@ CmdStatus Gpio::initPin(uint8_t const *cmd) {
         gpio_pull_up(gp);
     } else if(dir == GPIO_IN && cmd[3] == 2) {
         gpio_pull_down(gp);
-    } else {
+    } else if (dir == GPIO_IN) {
         gpio_disable_pulls(gp);
     }
     //a voir gpio_set_outover(gpio, GPIO_OVERRIDE_INVERT);

--- a/firmware/source/interfaces/Gpio.cpp
+++ b/firmware/source/interfaces/Gpio.cpp
@@ -130,6 +130,8 @@ CmdStatus Gpio::initPin(uint8_t const *cmd) {
         gpio_pull_up(gp);
     } else if(dir == GPIO_IN && cmd[3] == 2) {
         gpio_pull_down(gp);
+    } else {
+        gpio_disable_pulls(gp);
     }
     //a voir gpio_set_outover(gpio, GPIO_OVERRIDE_INVERT);
     return CmdStatus::OK;


### PR DESCRIPTION
Currently GPIO pins get pulled low when the user sets Pin.PULL_NONE - the expected behaviour would be a floating pin...
This PR disables GPIO PULL when GPIO pull isn't UP or DOWN