### PR TITLE
Fix ADC GPIO range from 26-28 to 26-29

### DIFF
--- a/firmware/source/interfaces/Adc.cpp
+++ b/firmware/source/interfaces/Adc.cpp
@@ -32,7 +32,7 @@ CmdStatus Adc::task(uint8_t response[64]) {
 }
 
 int8_t Adc::getAdcIndexFromGpio(uint8_t gpio) {
-    if(gpio < 26 || gpio > 28)
+    if(gpio < 26 || gpio > 29)
         return -1;
     else
         return (static_cast<int8_t>(gpio)-26);

--- a/firmware/source/interfaces/Gpio.cpp
+++ b/firmware/source/interfaces/Gpio.cpp
@@ -130,7 +130,7 @@ CmdStatus Gpio::initPin(uint8_t const *cmd) {
         gpio_pull_up(gp);
     } else if(dir == GPIO_IN && cmd[3] == 2) {
         gpio_pull_down(gp);
-    } else {
+    } else if (dir == GPIO_IN) {
         gpio_disable_pulls(gp);
     }
     //a voir gpio_set_outover(gpio, GPIO_OVERRIDE_INVERT);

--- a/firmware/source/interfaces/Gpio.cpp
+++ b/firmware/source/interfaces/Gpio.cpp
@@ -130,6 +130,8 @@ CmdStatus Gpio::initPin(uint8_t const *cmd) {
         gpio_pull_up(gp);
     } else if(dir == GPIO_IN && cmd[3] == 2) {
         gpio_pull_down(gp);
+    } else {
+        gpio_disable_pulls(gp);
     }
     //a voir gpio_set_outover(gpio, GPIO_OVERRIDE_INVERT);
     return CmdStatus::OK;


### PR DESCRIPTION
> GPIO26-29 are shared with ADC inputs AIN0-3
https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf#page=564&zoom=100,153,865

- Basically GPIO29 wasn't being configured as ADC since getAdcIndexFromGpio returned -1 on GPIO 29

This also includes [this](https://github.com/execuc/u2if/pull/15) fix.